### PR TITLE
Enable Multi-Window Support

### DIFF
--- a/src/Enums.ts
+++ b/src/Enums.ts
@@ -122,6 +122,8 @@ export enum KeyboardAction {
     panePrevious,
     paneNext,
     paneClose,
+    windowSplitHorizontally,
+    windowSplitVertically,
     // edit/clipboard commands
     clipboardCopy,
     clipboardCut,
@@ -132,8 +134,8 @@ export enum KeyboardAction {
     editFind,
     editFindClose,
     // window commands
-    windowSplitHorizontally,
-    windowSplitVertically,
+    windowNew,
+    windowClose,
     // view commands
     viewReload,
     viewToggleFullScreen,

--- a/src/Keybindings.ts
+++ b/src/Keybindings.ts
@@ -1,5 +1,5 @@
-import {KeyCode, KeyboardAction} from "../../Enums";
-import {error} from "../../utils/Common";
+import {KeyCode, KeyboardAction} from "./Enums";
+import {error} from "./utils/Common";
 
 export type KeybindingType = {
     action: KeyboardAction,
@@ -119,6 +119,7 @@ const CopyAccelerator = process.platform === "darwin" ? "Command+C" : "Ctrl+Shif
 const ToggleFullScreenAccelerator = process.platform === "darwin" ? "Command+F" : "Ctrl+Shift+F";
 
 export const KeybindingsForMenu: KeybindingMenuType[] = [
+    // Tab commands
     {
         action: KeyboardAction.tabNew,
         accelerator: "CmdOrCtrl+T",
@@ -135,6 +136,8 @@ export const KeybindingsForMenu: KeybindingMenuType[] = [
         action: KeyboardAction.tabClose,
         accelerator: "CmdOrCtrl+W",
     },
+
+    // Pane commands
     {
         action: KeyboardAction.panePrevious,
         accelerator: "CmdOrCtrl+K",
@@ -147,7 +150,16 @@ export const KeybindingsForMenu: KeybindingMenuType[] = [
         action: KeyboardAction.paneClose,
         accelerator: "CmdOrCtrl+P",
     },
-    // edit/clipboard commands
+    {
+        action: KeyboardAction.windowSplitHorizontally,
+        accelerator: "CmdOrCtrl+-",
+    },
+    {
+        action: KeyboardAction.windowSplitVertically,
+        accelerator: "CmdOrCtrl+\\",
+    },
+
+    // Edit/clipboard commands
     {
         action: KeyboardAction.clipboardCopy,
         accelerator: CopyAccelerator,
@@ -180,16 +192,18 @@ export const KeybindingsForMenu: KeybindingMenuType[] = [
         action: KeyboardAction.editFindClose,
         accelerator: "Esc",
     },
-    // window commands
+
+    // Window commands
     {
-        action: KeyboardAction.windowSplitHorizontally,
-        accelerator: "CmdOrCtrl+-",
+        action: KeyboardAction.windowNew,
+        accelerator: "CmdOrCtrl+N",
     },
     {
-        action: KeyboardAction.windowSplitVertically,
-        accelerator: "CmdOrCtrl+\\",
+        action: KeyboardAction.windowClose,
+        accelerator: "CmdOrCtrl+Shift+W",
     },
-    // view commands
+
+    // View commands
     {
         action: KeyboardAction.viewReload,
         accelerator: "CmdOrCtrl+R",
@@ -198,7 +212,8 @@ export const KeybindingsForMenu: KeybindingMenuType[] = [
         action: KeyboardAction.viewToggleFullScreen,
         accelerator: ToggleFullScreenAccelerator,
     },
-    // black screen commands
+
+    // Application commands
     {
         action: KeyboardAction.blackScreenHide,
         accelerator: "CmdOrCtrl+H",
@@ -211,7 +226,8 @@ export const KeybindingsForMenu: KeybindingMenuType[] = [
         action: KeyboardAction.blackScreenHideOthers,
         accelerator: "CmdOrCtrl+Alt+H",
     },
-    // developer
+
+    // Developer commands
     {
         action: KeyboardAction.developerToggleTools,
         accelerator: "CmdOrCtrl+Alt+I",

--- a/src/main/Main.ts
+++ b/src/main/Main.ts
@@ -25,14 +25,14 @@ app.on("ready", () => {
     createWindow();
     registerApplicationMenu();
 
-    globalShortcut.register('CommandOrControl+N', () => {
+    globalShortcut.register("CommandOrControl+N", () => {
         createWindow();
-    })
+    });
 });
 
 app.on("window-all-closed", () => {
     // On OSX the app usually keeps running until Cmd+Q'd.
-    if (process.platform !== 'darwin') {
+    if (process.platform !== "darwin") {
         app.quit();
     }
 });
@@ -83,9 +83,9 @@ export function createWindow() {
         browserWindow.focus();
     });
 
-    browserWindow.on('closed', () => {
+    browserWindow.on("closed", () => {
         closeWindow(browserWindow);
-    })
+    });
 
     windows.push(browserWindow);
 }
@@ -103,8 +103,7 @@ function closeWindow(browserWindow: Electron.BrowserWindow) {
     let next_window = Math.min(index, windows.length);
     if (next_window > -1) {
         windows[next_window].focus();
-    }
-    else {
+    } else {
         focussedWindowIndex = -1;
     }
 }

--- a/src/main/Main.ts
+++ b/src/main/Main.ts
@@ -1,12 +1,52 @@
-import {app, ipcMain, nativeImage, BrowserWindow, screen} from "electron";
+import {app, nativeImage, BrowserWindow, screen, globalShortcut, Menu} from "electron";
 import {readFileSync} from "fs";
 import {windowBoundsFilePath} from "../utils/Common";
+import {buildMenuTemplate} from "./Menu";
+
+/**
+ * Contains references to all currently open windows.
+ *
+ * @type {Array}
+ */
+let windows: Electron.BrowserWindow[] = [];
+
+/**
+ * The index of the currently focussed window in `windows`.
+ *
+ * @type {number}
+ */
+let focussedWindowIndex: number;
 
 if (app.dock) {
     app.dock.setIcon(nativeImage.createFromPath("build/icon.png"));
 }
 
 app.on("ready", () => {
+    createWindow();
+    registerApplicationMenu();
+
+    globalShortcut.register('CommandOrControl+N', () => {
+        createWindow();
+    })
+});
+
+app.on("window-all-closed", () => {
+    // On OSX the app usually keeps running until Cmd+Q'd.
+    if (process.platform !== 'darwin') {
+        app.quit();
+    }
+});
+
+app.on("open-file", (_event, file) => {
+    if (focussedWindowIndex > -1) {
+        windows[focussedWindowIndex].webContents.send("change-working-directory", file);
+    }
+});
+
+/**
+ * Create a new terminal window and push it to `windows`.
+ */
+export function createWindow() {
     const bounds = windowBounds();
 
     let options: Electron.BrowserWindowOptions = {
@@ -32,20 +72,65 @@ app.on("ready", () => {
 
     browserWindow.loadURL("file://" + __dirname + "/../views/index.html");
 
-    browserWindow.on("focus", () => app.dock && app.dock.setBadge(""));
+    browserWindow.on("focus", () => {
+        app.dock;
+        app.dock.setBadge("");
+        setFocssedWindow(browserWindow);
+    });
 
     browserWindow.webContents.on("did-finish-load", () => {
         browserWindow.show();
         browserWindow.focus();
     });
 
-    app.on("open-file", (_event, file) => browserWindow.webContents.send("change-working-directory", file));
-});
+    browserWindow.on('closed', () => {
+        closeWindow(browserWindow);
+    })
 
-app.on("window-all-closed", () => app.quit());
+    windows.push(browserWindow);
+}
 
-ipcMain.on("quit", app.quit);
+/**
+ * Remove a window from the `windows` list.
+ *
+ * @param {BrowserWindow} browserWindow the window to remove
+ */
+function closeWindow(browserWindow: Electron.BrowserWindow) {
+    let index = windows.indexOf(browserWindow);
+    windows.splice(index, 1);
 
+    // Focus next window
+    let next_window = Math.min(index, windows.length);
+    if (next_window > -1) {
+        windows[next_window].focus();
+    }
+    else {
+        focussedWindowIndex = -1;
+    }
+}
+
+/**
+ * Set `focussedWindowIndex` to the index of the passed-in BrowserWindow.
+ *
+ * @param {Electron.BrowserWindow} browserWindow
+ */
+function setFocssedWindow(browserWindow: Electron.BrowserWindow) {
+    focussedWindowIndex = windows.indexOf(browserWindow);
+}
+
+/**
+ * Register the global application menu.
+ */
+function registerApplicationMenu() {
+    const template = buildMenuTemplate(app);
+    Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}
+
+/**
+ * Get the maximum possible window dimensions on the display.
+ *
+ * @return {Electron.Rectangle}
+ */
 function windowBounds(): Electron.Rectangle {
     try {
         return JSON.parse(readFileSync(windowBoundsFilePath).toString());

--- a/src/main/Main.ts
+++ b/src/main/Main.ts
@@ -25,9 +25,7 @@ app.on("ready", () => {
     createWindow();
     registerApplicationMenu();
 
-    globalShortcut.register("CommandOrControl+N", () => {
-        createWindow();
-    });
+    globalShortcut.register("CommandOrControl+N", createWindow);
 });
 
 app.on("window-all-closed", () => {
@@ -76,7 +74,7 @@ export function createWindow() {
         if (app.dock) {
             app.dock.setBadge("");
         }
-        setFocssedWindow(browserWindow);
+        setFocussedWindow(browserWindow);
     });
 
     browserWindow.webContents.on("did-finish-load", () => {
@@ -114,7 +112,7 @@ function closeWindow(browserWindow: Electron.BrowserWindow) {
  *
  * @param {Electron.BrowserWindow} browserWindow
  */
-function setFocssedWindow(browserWindow: Electron.BrowserWindow) {
+function setFocussedWindow(browserWindow: Electron.BrowserWindow) {
     focussedWindowIndex = windows.indexOf(browserWindow);
 }
 

--- a/src/main/Main.ts
+++ b/src/main/Main.ts
@@ -73,8 +73,9 @@ export function createWindow() {
     browserWindow.loadURL("file://" + __dirname + "/../views/index.html");
 
     browserWindow.on("focus", () => {
-        app.dock;
-        app.dock.setBadge("");
+        if (app.dock) {
+            app.dock.setBadge("");
+        }
         setFocssedWindow(browserWindow);
     });
 

--- a/src/main/Menu.ts
+++ b/src/main/Menu.ts
@@ -1,10 +1,10 @@
-import {KeyboardAction, SplitDirection} from "../../Enums";
-import {remote} from "electron";
-import {getAcceleratorForAction} from "../keyevents/Keybindings";
+import {KeyboardAction} from "../Enums";
+import {shell} from "electron";
+import {getAcceleratorForAction} from "../Keybindings";
+import {createWindow} from "./Main";
 
 
-
-export function buildMenuTemplate(app: Electron.App, browserWindow: Electron.BrowserWindow): Electron.MenuItemOptions[] {
+export function buildMenuTemplate(app: Electron.App): Electron.MenuItemOptions[] {
     const template: Electron.MenuItemOptions[] = [
         {
             label: "Black Screen",
@@ -91,22 +91,52 @@ export function buildMenuTemplate(app: Electron.App, browserWindow: Electron.Bro
                 {
                     label: "Reload",
                     accelerator: getAcceleratorForAction(KeyboardAction.viewReload),
-                    click: () => {
-                        browserWindow.reload();
+                    click: (_item, browserWindow) => {
+                        if (browserWindow) {
+                            browserWindow.reload();
+                        }
                     },
                 },
                 {
                     label: "Toggle Full Screen",
                     accelerator: getAcceleratorForAction(KeyboardAction.viewToggleFullScreen),
-                    click: () => {
-                        browserWindow.setFullScreen(!browserWindow.isFullScreen());
+                    click: (_item, browserWindow) => {
+                        if (browserWindow) {
+                            browserWindow.setFullScreen(!browserWindow.isFullScreen());
+                        }
                     },
                 },
                 {
                     label: "Toggle Developer Tools",
                     accelerator: getAcceleratorForAction(KeyboardAction.developerToggleTools),
+                    click: (_item, browserWindow) => {
+                        if (browserWindow) {
+                            browserWindow.webContents.toggleDevTools();
+                        }
+                    },
+                },
+            ],
+        },
+        {
+            label: "Window",
+            submenu: [
+                {
+                    label: "New Window",
+                    accelerator: getAcceleratorForAction(KeyboardAction.windowNew),
                     click: () => {
-                        browserWindow.webContents.toggleDevTools();
+                        createWindow();
+                    },
+                },
+                {
+                    type: "separator",
+                },
+                {
+                    label: "Close Window",
+                    accelerator: getAcceleratorForAction(KeyboardAction.windowClose),
+                    click: (_item, browserWindow) => {
+                        if (browserWindow) {
+                            browserWindow.close();
+                        }
                     },
                 },
             ],
@@ -117,8 +147,10 @@ export function buildMenuTemplate(app: Electron.App, browserWindow: Electron.Bro
                 {
                     label: "New Tab",
                     accelerator: getAcceleratorForAction(KeyboardAction.tabNew),
-                    click: () => {
-                        window.application.addTab();
+                    click: (_item, browserWindow) => {
+                        if (browserWindow) {
+                            browserWindow.webContents.send("add-tab");
+                        }
                     },
                 },
                 {
@@ -127,17 +159,19 @@ export function buildMenuTemplate(app: Electron.App, browserWindow: Electron.Bro
                 {
                     label: "Previous",
                     accelerator: getAcceleratorForAction(KeyboardAction.tabPrevious),
-                    click: () => {
-                        window.application.activatePreviousTab();
-                        window.application.forceUpdate();
+                    click: (_item, browserWindow) => {
+                        if (browserWindow) {
+                            browserWindow.webContents.send("activate-previous-tab");
+                        }
                     },
                 },
                 {
                     label: "Next",
                     accelerator: getAcceleratorForAction(KeyboardAction.tabNext),
-                    click: () => {
-                        window.application.activateNextTab();
-                        window.application.forceUpdate();
+                    click: (_item, browserWindow) => {
+                        if (browserWindow) {
+                            browserWindow.webContents.send("activate-next-tab");
+                        }
                     },
                 },
                 {
@@ -146,9 +180,10 @@ export function buildMenuTemplate(app: Electron.App, browserWindow: Electron.Bro
                 {
                     label: "Close",
                     accelerator: getAcceleratorForAction(KeyboardAction.tabClose),
-                    click: () => {
-                        window.application.closeFocusedTab();
-                        window.application.forceUpdate();
+                    click: (_item, browserWindow) => {
+                        if (browserWindow) {
+                            browserWindow.webContents.send("close-focused-tab");
+                        }
                     },
                 },
             ],
@@ -159,17 +194,19 @@ export function buildMenuTemplate(app: Electron.App, browserWindow: Electron.Bro
                 {
                     label: "Split Horizontally",
                     accelerator: getAcceleratorForAction(KeyboardAction.windowSplitHorizontally),
-                    click: () => {
-                        window.focusedTab.addPane(SplitDirection.Horizontal);
-                        window.application.forceUpdate();
+                    click: (_item, browserWindow) => {
+                        if (browserWindow) {
+                            browserWindow.webContents.send("split-horizontally");
+                        }
                     },
                 },
                 {
                     label: "Split Vertically",
                     accelerator: getAcceleratorForAction(KeyboardAction.windowSplitVertically),
-                    click: () => {
-                        window.focusedTab.addPane(SplitDirection.Vertical);
-                        window.application.forceUpdate();
+                    click: (_item, browserWindow) => {
+                        if (browserWindow) {
+                            browserWindow.webContents.send("split-vertically");
+                        }
                     },
                 },
                 {
@@ -178,17 +215,19 @@ export function buildMenuTemplate(app: Electron.App, browserWindow: Electron.Bro
                 {
                     label: "Previous",
                     accelerator: getAcceleratorForAction(KeyboardAction.panePrevious),
-                    click: () => {
-                        window.focusedTab.activatePreviousPane();
-                        window.application.forceUpdate();
+                    click: (_item, browserWindow) => {
+                        if (browserWindow) {
+                            browserWindow.webContents.send("activate-previous-pane");
+                        }
                     },
                 },
                 {
                     label: "Next",
                     accelerator: getAcceleratorForAction(KeyboardAction.paneNext),
-                    click: () => {
-                        window.focusedTab.activateNextPane();
-                        window.application.forceUpdate();
+                    click: (_item, browserWindow) => {
+                        if (browserWindow) {
+                            browserWindow.webContents.send("activate-next-pane");
+                        }
                     },
                 },
                 {
@@ -197,9 +236,10 @@ export function buildMenuTemplate(app: Electron.App, browserWindow: Electron.Bro
                 {
                     label: "Close",
                     accelerator: getAcceleratorForAction(KeyboardAction.paneClose),
-                    click: () => {
-                        window.application.closeFocusedPane();
-                        window.application.forceUpdate();
+                    click: (_item, browserWindow) => {
+                        if (browserWindow) {
+                            browserWindow.webContents.send("close-focused-pane");
+                        }
                     },
                 },
             ],
@@ -211,7 +251,7 @@ export function buildMenuTemplate(app: Electron.App, browserWindow: Electron.Bro
                     label: "GitHub Repository",
                     click: () => {
                         /* tslint:disable:no-unused-expression */
-                        remote.shell.openExternal("https://github.com/shockone/black-screen");
+                        shell.openExternal("https://github.com/shockone/black-screen");
                     },
                 },
             ],

--- a/src/main/Menu.ts
+++ b/src/main/Menu.ts
@@ -56,8 +56,10 @@ export function buildMenuTemplate(app: Electron.App): Electron.MenuItemOptions[]
                 {
                     label: "Find",
                     accelerator: getAcceleratorForAction(KeyboardAction.editFind),
-                    click: () => {
-                        (document.querySelector("input[type=search]") as HTMLInputElement).select();
+                    click: (_item, browserWindow) => {
+                        if (browserWindow) {
+                            browserWindow.webContents.send("focus-search-input");
+                        }
                     },
                 },
                 {

--- a/src/shell/Session.ts
+++ b/src/shell/Session.ts
@@ -38,7 +38,7 @@ export class Session extends EmitterWithUniqueID {
         const job = new Job(this);
 
         job.once("end", () => {
-            const electronWindow = remote.BrowserWindow.getAllWindows()[0];
+            const electronWindow = remote.getCurrentWindow();
 
             if (remote.app.dock && !electronWindow.isFocused()) {
                 remote.app.dock.bounce("informational");

--- a/src/views/1_ApplicationComponent.tsx
+++ b/src/views/1_ApplicationComponent.tsx
@@ -71,6 +71,11 @@ export class ApplicationComponent extends React.Component<{}, {}> {
             .on("close-focused-pane", () => {
                 this.closeFocusedPane();
                 this.forceUpdate();
+            })
+
+            // Content actions
+            .on("focus-search-input", () => {
+                (document.querySelector("input[type=search]") as HTMLInputElement).select();
             });
 
         window.onbeforeunload = () => {

--- a/src/views/1_ApplicationComponent.tsx
+++ b/src/views/1_ApplicationComponent.tsx
@@ -39,8 +39,8 @@ export class ApplicationComponent extends React.Component<{}, {}> {
             )
             .on("add-tab", () => this.addTab())
             .on("close-focused-tab", () => {
-                this.closeFocusedTab()
-                this.forceUpdate()
+                this.closeFocusedTab();
+                this.forceUpdate();
             })
             .on("activate-previous-tab", () => {
                 this.activatePreviousTab();

--- a/src/views/1_ApplicationComponent.tsx
+++ b/src/views/1_ApplicationComponent.tsx
@@ -9,33 +9,72 @@ import {saveWindowBounds} from "./ViewUtils";
 import {StatusBarComponent} from "./StatusBarComponent";
 import {PaneTree, Pane} from "../utils/PaneTree";
 import {SearchComponent} from "./SearchComponent";
+import {SplitDirection} from "../Enums";
 
 export class ApplicationComponent extends React.Component<{}, {}> {
     private tabs: Tab[] = [];
     private focusedTabIndex: number;
+    private electronWindow: Electron.BrowserWindow = remote.getCurrentWindow();
 
     constructor(props: {}) {
         super(props);
-        const electronWindow = remote.BrowserWindow.getAllWindows()[0];
 
         this.addTab(false);
 
-        electronWindow
-            .on("move", () => saveWindowBounds(electronWindow))
+        this.electronWindow
+            .on("move", () => saveWindowBounds(this.electronWindow))
             .on("resize", () => {
-                saveWindowBounds(electronWindow);
+                saveWindowBounds(this.electronWindow);
                 this.recalculateDimensions();
-            })
-            .webContents
+            });
+
+        this.electronWindow.webContents
             .on("devtools-opened", () => this.recalculateDimensions())
             .on("devtools-closed", () => this.recalculateDimensions());
 
-        ipcRenderer.on("change-working-directory", (_event: Electron.IpcRendererEvent, directory: string) =>
-            this.focusedTab.focusedPane.session.directory = directory,
-        );
+        ipcRenderer
+            // Tabs actions
+            .on("change-working-directory", (_event: Electron.IpcRendererEvent, directory: string) =>
+                this.focusedTab.focusedPane.session.directory = directory,
+            )
+            .on("add-tab", () => this.addTab())
+            .on("close-focused-tab", () => {
+                this.closeFocusedTab()
+                this.forceUpdate()
+            })
+            .on("activate-previous-tab", () => {
+                this.activatePreviousTab();
+                this.forceUpdate();
+            })
+            .on("activate-next-tab", () => {
+                this.activateNextTab();
+                this.forceUpdate();
+            })
+
+            // Panels actions
+            .on("split-horizontally", () => {
+                window.focusedTab.addPane(SplitDirection.Horizontal);
+                this.forceUpdate();
+            })
+            .on("split-vertically", () => {
+                window.focusedTab.addPane(SplitDirection.Vertical);
+                this.forceUpdate();
+            })
+            .on("activate-previous-pane", () => {
+                window.focusedTab.activatePreviousPane();
+                this.forceUpdate();
+            })
+            .on("activate-next-pane", () => {
+                window.focusedTab.activateNextPane();
+                this.forceUpdate();
+            })
+            .on("close-focused-pane", () => {
+                this.closeFocusedPane();
+                this.forceUpdate();
+            });
 
         window.onbeforeunload = () => {
-            electronWindow
+            this.electronWindow
                 .removeAllListeners()
                 .webContents
                 .removeAllListeners("devtools-opened")
@@ -182,7 +221,7 @@ export class ApplicationComponent extends React.Component<{}, {}> {
         _.pull(this.tabs, tab);
 
         if (this.tabs.length === 0 && quit) {
-            ipcRenderer.send("quit");
+            this.electronWindow.close();
         } else if (this.tabs.length === this.focusedTabIndex) {
             this.focusedTabIndex -= 1;
         }

--- a/src/views/SearchComponent.tsx
+++ b/src/views/SearchComponent.tsx
@@ -4,7 +4,7 @@ import {remote} from "electron";
 import {fontAwesome} from "./css/FontAwesome";
 
 export class SearchComponent extends React.Component<{}, {}> {
-    private webContents: Electron.WebContents = remote.BrowserWindow.getAllWindows()[0].webContents;
+    private webContents: Electron.WebContents = remote.getCurrentWindow().webContents;
 
     constructor() {
         super();

--- a/src/views/UserEventsHander.ts
+++ b/src/views/UserEventsHander.ts
@@ -6,9 +6,7 @@ import {Tab} from "./TabComponent";
 import {Status, KeyboardAction} from "../Enums";
 import {isModifierKey} from "./ViewUtils";
 import {SearchComponent} from "./SearchComponent";
-import {remote} from "electron";
-import {buildMenuTemplate} from "./menu/Menu";
-import {isKeybindingForEvent} from "./keyevents/Keybindings";
+import {isKeybindingForEvent} from "../Keybindings";
 
 export type UserEvent = KeyboardEvent | ClipboardEvent;
 
@@ -206,9 +204,3 @@ export const handleUserEvent = (
 function isInProgress(job: JobComponent): boolean {
     return job.props.job.status === Status.InProgress;
 }
-
-const app = remote.app;
-const browserWindow = remote.BrowserWindow.getAllWindows()[0];
-const template = buildMenuTemplate(app, browserWindow);
-
-remote.Menu.setApplicationMenu(remote.Menu.buildFromTemplate(template));


### PR DESCRIPTION
- Allow multiple windows (fixes #922)
- Keep application running on osx after all windows have been closed (fixes #365)

Changes and refactoring applied to achieve this:
- Store window instances in `windows` global in `main/Main.ts`
- Introduce methods for window handling including focussed window in `main/Main.ts`
- Add menu items and keybindings for new/close window
- Make the `electronWindow` a property of the `ApplicationComponent` so we can `.close()` it when all tabs are gone
- Move `Menu.ts` to `src/main/` and register it from within the main process, don't bind the handlers to specifit windows
- Create handlers in `ApplicationComponent` for all menu events so we can call them on the currently focussed window
- Move `Keybindings.ts` to `src/`