### PR TITLE
Allow word wrapping in the prompt.

### DIFF
--- a/src/views/4_PromptComponent.tsx
+++ b/src/views/4_PromptComponent.tsx
@@ -150,7 +150,7 @@ export class PromptComponent extends React.Component<Props, State> {
                 </div>
                 <div
                     className="prompt" // Used by tests
-                    style={css.prompt(this.state.isSticky)}
+                    style={css.prompt}
                     onInput={this.handleInput.bind(this)}
                     onDrop={this.handleDrop.bind(this)}
                     onBlur={() => this.setState({...this.state, caretPositionFromPreviousFocus: getCaretPosition(this.commandNode)})}

--- a/src/views/css/main.ts
+++ b/src/views/css/main.ts
@@ -74,6 +74,7 @@ const applicationGrid = {
     },
     sessions: {
         height: "100%",
+        maxWidth: "100%",
     },
 };
 
@@ -81,9 +82,11 @@ const sessionGrid = {
     container: {
         display: "grid",
         gridTemplateAreas: "'all'",
+        gridTemplateColumns: "100%",
     },
     child: {
         gridArea: "all",
+        maxWidth: "100%",
     },
 };
 
@@ -474,7 +477,6 @@ export const promptWrapper = (status: Status, isSticky: boolean) => {
         styles.width = "100%";
         styles.position = "fixed";
         styles.top = titleBarHeight;
-        styles.height = promptWrapperHeight;
     }
 
     if ([Status.Failure, Status.Interrupted].includes(status)) {
@@ -548,12 +550,13 @@ export const autocompletedPreview = {
     color: lighten(promptBackgroundColor, 15),
 };
 
-export const prompt = (isSticky: boolean) => ({
+export const prompt = {
     ...promptInlineElement,
     color: colors.white,
     zIndex: 2,
-    whiteSpace: isSticky ? "nowrap" : "pre-wrap",
-});
+    whiteSpace: "pre-wrap",
+    wordBreak: "break-word",
+};
 
 export const promptPlaceholder = {
     minHeight: promptWrapperHeight,


### PR DESCRIPTION
This requires several changes:

 - Set several containers max-width to 100%
 - Don't force a height on the prompt
 - Allow wrapping when necessary in the prompt (pre-wrap)
 - Force word breaks when necessary in the prompt

Fixes #963