### PR TITLE
Updated README to include an Arch Linux install guide (yaourt).

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Beware that the version in Homebrew might be outdated. Visit the [releases](http
 
 ###### Linux *(Arch Linux)*
 ```bash
-yaourt -S black-screen
+yaourt -S upterm
 ```
 
 As with macOS's `brew` install, the AUR may also be outdated. To install the latest version, refer to the [install guide for Linux (Others)](#linux-others).

--- a/README.md
+++ b/README.md
@@ -33,7 +33,14 @@ brew cask install black-screen
 
 Beware that the version in Homebrew might be outdated. Visit the [releases](https://github.com/railsware/black-screen/releases) page to download the latest version.
 
-###### Linux
+###### Linux *(Arch Linux)*
+```bash
+yaourt -S black-screen
+```
+
+As with macOS's `brew` install, the AUR may also be outdated. To install the latest version, refer to the [install guide for Linux (Others)](#linux-others).
+
+###### Linux *(Others)*
 
 * `git clone https://github.com/railsware/black-screen.git`
 * `cd black-screen`


### PR DESCRIPTION
Added a new install entry to README for Arch Linux users since Black Screen is available for automated install via `yaourt` (AUR).