### PR TITLE
Changed the macOS ⌘ symbol to 'Ctrl+' on non-darwin platforms.

### DIFF
--- a/src/views/TabComponent.tsx
+++ b/src/views/TabComponent.tsx
@@ -6,6 +6,8 @@ import * as css from "./css/styles";
 import {fontAwesome} from "./css/FontAwesome";
 import {Pane, PaneList} from "../utils/PaneTree";
 
+const os = require("os");
+
 export interface TabProps {
     isFocused: boolean;
     activate: () => void;
@@ -43,8 +45,8 @@ export class TabComponent extends React.Component<TabProps, TabState> {
                     {fontAwesome.times}
                 </span>
 
-                <span style={css.commandSign}>⌘</span>
-                <span>{this.props.position}</span>
+                <span style={os.platform() === "darwin" ? css.commandSign : css.vertAlignMiddle}>{os.platform() === "darwin" ? "⌘" : "Ctrl+"}</span>
+                <span style={css.vertAlignMiddle}>{this.props.position}</span>
             </li>
         );
     }

--- a/src/views/css/styles.ts
+++ b/src/views/css/styles.ts
@@ -225,6 +225,10 @@ export const commandSign = {
     verticalAlign: "middle",
 };
 
+export const vertAlignMiddle = {
+    verticalAlign: "middle",
+};
+
 // To display even empty rows. The height might need tweaking.
 // TODO: Remove if we always have a fixed output width.
 export const charGroup = (attributes: Attributes) => {


### PR DESCRIPTION
Revisions to the Tab Component to change the ⌘ into *Ctrl+* if the platform is not **darwin *(macOS/Mac OS X)*.**

*(I'd recommend for someone with a Mac to first test if ⌘ instead appears if upterm is ran on a Mac. I "peasant-tested" this by switching the if shorthand **(TabComponent.tsx, line 48)** between `win32` and `darwin`. It seems to be working.)*

**QUICK CHANGES:**
* Excluded the `package-lock.json` file. *(Closing #1140 in favor of this.)*