### PR TITLE
Check command exists before registering auto-complete provider

### DIFF
--- a/src/PluginManager.ts
+++ b/src/PluginManager.ts
@@ -1,6 +1,6 @@
 import {Prettyfier, EnvironmentObserverPlugin, AutocompletionProvider} from "./Interfaces";
 import * as Path from "path";
-import {io} from "./utils/Common";
+import {commandExists, io} from "./utils/Common";
 import {environmentVariableSuggestions, anyFilesSuggestionsProvider} from "../src/plugins/autocompletion_utils/Common";
 import {combine} from "../src/plugins/autocompletion_utils/Combine";
 
@@ -29,14 +29,17 @@ export class PluginManager {
     }
 
     static registerAutocompletionProvider(commandName: string, provider: AutocompletionProvider): void {
-        this._autocompletionProviders[commandName] = provider;
+        commandExists(commandName)
+        .then(exists => {
+            if (exists)
+                this._autocompletionProviders[commandName] = provider;
+        });
     }
 
     static autocompletionProviderFor(commandName: string): AutocompletionProvider {
         return this._autocompletionProviders[commandName] || defaultAutocompletionProvider;
     }
 }
-
 
 export async function loadAllPlugins(): Promise<void> {
     const pluginsDirectory = Path.join(__dirname, "plugins");

--- a/src/utils/Common.ts
+++ b/src/utils/Common.ts
@@ -6,6 +6,7 @@ import * as _ from "lodash";
 import * as fs from "fs-extra";
 import {KeyCode} from "./../Enums";
 import {EnvironmentPath} from "../shell/Environment";
+import {executeCommand} from "../PTY";
 
 interface FSExtraWalkObject {
     path: string;
@@ -89,6 +90,24 @@ export const io = {
         return _.uniq(_.flatten(allFiles));
     },
     realPath: fs.realpath,
+};
+
+export const commandExists = async (commandName: string): Promise<boolean> => {
+    let result = false;
+    try {
+        const output = await executeCommand(
+            "command",
+            ['"-v"', commandName],
+            ".",
+        );
+        if (output)
+            result = true;
+    } catch (error) {
+        if (!error.message.startsWith("Command failed: command"))
+            throw error;
+    } finally {
+        return result;
+    }
 };
 
 /**


### PR DESCRIPTION
Check that a command exists before adding it the command auto-complete provider list.

Possible fix for issue #1203.