### PR TITLE
Delegate cmd-f to search component.

### DIFF
--- a/src/views/PromptComponent.tsx
+++ b/src/views/PromptComponent.tsx
@@ -82,6 +82,11 @@ export class PromptComponent extends React.Component<Props, State> {
             () => this.setNextHistoryItem(),
             "!suggestWidgetVisible",
         );
+        this.editor.addCommand(
+            monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_F,
+            () => (document.querySelector("input[type=search]") as HTMLInputElement).select(),
+            "editorFocus",
+        );
         this.addShortcut(
             monaco.KeyMod.WinCtrl | monaco.KeyCode.KEY_B,
             "cursorLeft",


### PR DESCRIPTION
Fix #1180. 

Right now we don't have a way to disable a keybinding and still populate key events in Monaco (a good feature request though I admit). So here I use the same way as Menu to trigger focus on Search Component.