### PR TITLE
Fix #1081. Refocus prompt when escape from search component.

### DIFF
--- a/src/views/keyevents/Keybindings.ts
+++ b/src/views/keyevents/Keybindings.ts
@@ -303,6 +303,7 @@ export function handleUserEvent(application: ApplicationComponent, search: Searc
         // Search close
         if (isKeybindingForEvent(event, KeyboardAction.editFindClose)) {
             search.clearSelection();
+            promptComponent.focus();
 
             event.stopPropagation();
             event.preventDefault();


### PR DESCRIPTION
Search is focused and we need to give the focus back to prompt.