### PR TITLE
Tab Headers Legibility Improvements

### DIFF
--- a/src/views/index.html
+++ b/src/views/index.html
@@ -127,12 +127,12 @@
                 flex-grow: 1;
                 display: flex;
                 text-align: center;
-                border: 1px solid #191C22;
+                border: 1px solid rgba(255, 255, 255, 0.2);
                 font-size: 0.852em;
                 border-top: 0;
-                border-bottom: 0;
                 align-items: center;
                 justify-content: center;
+                border-radius: 0 0 5px 5px;
             }
 
             .tab-header[data-focused=true] {

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -127,7 +127,7 @@
                 flex-grow: 1;
                 display: flex;
                 text-align: center;
-                border: 1px solid rgba(255, 255, 255, 0.2);
+                border: 1px solid #FFFFFF20;
                 font-size: 0.852em;
                 border-top: 0;
                 align-items: center;
@@ -138,7 +138,7 @@
             .tab-header[data-focused=true] {
                 opacity: 1;
 
-                background-color: rgba(255, 255, 255, 0.1);
+                background-color: #FFFFFF10;
             }
 
             .tab-header:hover {


### PR DESCRIPTION
Making the active tab a bit more apparent with borders and background color.

Before:

<img width="522" alt="screen shot 2018-09-14 at 12 31 13 pm" src="https://user-images.githubusercontent.com/9244728/45571133-1c676a00-b81a-11e8-8c39-68c139f959d6.png">

After:

<img width="626" alt="screen shot 2018-09-14 at 12 26 45 pm" src="https://user-images.githubusercontent.com/9244728/45571174-428d0a00-b81a-11e8-9458-4ef347c0499d.png">

Fixes item 3 in https://github.com/railsware/upterm/issues/1192.