### PR TITLE
Change engines field

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,8 @@
   "bugs": {
     "url": "https://github.com/railsware/upterm/issues"
   },
-  "engineStrict": true,
   "engines": {
-    "node": ">= 6.0.0"
+    "node": ">=8.0.0 || >=10.0.0"
   },
   "keywords": [
     "terminal",


### PR DESCRIPTION
I tested this on 10 and 11. 10 is current LTS, and 6 and 8 aren't getting regular updates, but I left 8 in there because that's what's in the nvmrc.